### PR TITLE
Replaces illegal characters with underscore

### DIFF
--- a/tax2sap.py
+++ b/tax2sap.py
@@ -64,13 +64,13 @@ def main(in_file, out_file):
             rank_str = ">" + gi + " ; "
             for node in tax_path:
                 if node['rank'] in accepted_taxon_ranks:
-                    rank_str = rank_str + node['rank'].replace(",", "_")  + ": " + (node['rank_name']) + ", "
+                    rank_str = rank_str + node['rank'].replace(",", "_").replace(";", "_").replace(":", "_")  + ": " + (node['rank_name']).replace(",", "_").replace(";", "_").replace(":", "_") + ", "
 
             rank_str = rank_str[0:-2]
             rank_str = rank_str + " ; " + id
             rank_str = re.sub (r'<.*>', "", rank_str)
             if output is not None:
-                output.write(rank_str)
+                output.write(rank_str + '\n')
             else: # STDOUT
                 sys.stdout.write(rank_str + '\n')
         except Exception:


### PR DESCRIPTION
',', ':', and ';' are all used in SAP headers, so they are replaced with '_' when found in any scientific names. For example when "BOLD:9863" is attached of the species name in NCBI. 